### PR TITLE
Add read_uuid option

### DIFF
--- a/ble_serial/__main__.py
+++ b/ble_serial/__main__.py
@@ -22,6 +22,8 @@ def main():
         help='Enable optional logging of all bluetooth traffic to file')
     parser.add_argument('-p', '--port', dest='port', required=False, default='/tmp/ttyBLE',
         help='Symlink to virtual serial port')
+    parser.add_argument('-r', '--read-uuid', dest='read_uuid', required=False,
+        help='The GATT characteristic to subscribe to notifications to read the serial data')
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -32,7 +34,7 @@ def main():
 
     try:
         uart = UART(args.port)
-        bt = BLE_interface(args.device, args.addr_type, args.adapter, args.write_uuid)
+        bt = BLE_interface(args.device, args.addr_type, args.adapter, args.write_uuid, args.read_uuid)
         if args.filename:
             log = FS_log(args.filename)
             bt.set_receiver(log.middleware(Direction.BLE_IN, uart.write_sync))


### PR DESCRIPTION
In some implementations, a BLE UART uses notifications/indications to send data to the recipient as it is available. 

The `--read-uuid` AKA `-r` option introduced in this commit allows the user to specify a Gatt Characteristic UUID that ble-serial will attempt to subscribe to notifications from by writing the CCCD of that characteristic.

Known limitations:
- This option does not currently allow users to enable indications nor both notifications and indications at the same time.