### PR TITLE
Allow characteristics with indicate property

### DIFF
--- a/ble_serial/bluetooth/ble_interface.py
+++ b/ble_serial/bluetooth/ble_interface.py
@@ -28,7 +28,7 @@ class BLE_interface():
             logging.info('Writing disabled, skipping write UUID detection')
         
         if self.read_enabled:
-            self.read_char = self.find_char(read_uuid, ['notify'])
+            self.read_char = self.find_char(read_uuid, ['notify', 'indicate'])
             await self.dev.start_notify(self.read_char, self.handle_notify)
         else:
             logging.info('Reading disabled, skipping read UUID detection')


### PR DESCRIPTION
Some devices use `indicate` instead of `notify`:

```
% python3.9 -m ble_serial.scan -d 9E4F9433-7AAF-40F2-8395-0E8DE14EE265
Started deep scan of 9E4F9433-7AAF-40F2-8395-0E8DE14EE265

SERVICE 0bd51666-e7cb-469b-8e4d-2742f1ba77cc (Handle: 6): Unknown
     CHARACTERISTIC e7add780-b042-4876-aae1-112855353cc1 (Handle: 7): Unknown ['write', 'indicate']
         DESCRIPTOR 00002902-0000-1000-8000-00805f9b34fb (Handle: 9): Client Characteristic Configuration
         DESCRIPTOR 00002901-0000-1000-8000-00805f9b34fb (Handle: 10): Characteristic User Description

Completed deep scan of 9E4F9433-7AAF-40F2-8395-0E8DE14EE265
```

This simply allows for `indicate` to be used for receiving messages from a BLE device. Tested this with my EEVBlog 121GW multimeter, which supports BLE.