### PR TITLE
Service based scanning (macOS 12 workaround)

### DIFF
--- a/ble_serial/bluetooth/ble_interface.py
+++ b/ble_serial/bluetooth/ble_interface.py
@@ -6,22 +6,20 @@ import logging, asyncio
 from typing import Optional
 
 class BLE_interface():
-    def __init__(self):
+    def __init__(self, adapter: str, addr_type: str, service: str):
         self._send_queue = asyncio.Queue()
 
-    async def connect(self, addr_str: str, addr_type: str, adapter: str, timeout: float, service: str):
-        
-        # TODO move args gen to separate function
-        scan_args = dict(adapter=adapter, address_type=addr_type)
+        self.scan_args = dict(adapter=adapter, address_type=addr_type)
         if service:
-            scan_args['service_uuids'] = [service]
+            self.scan_args['service_uuids'] = [service]
 
+    async def connect(self, addr_str: str, timeout: float):
         if addr_str:
-            device = await BleakScanner.find_device_by_address(addr_str, timeout=timeout, **scan_args)
+            device = await BleakScanner.find_device_by_address(addr_str, timeout=timeout, **self.scan_args)
         else:
-            logging.warning(f'Picking first device with service {service}, '
+            logging.warning(f'Picking first device with matching service, '
                 'consider passing a specific device address, especially if there could be multiple devices')
-            device = await BleakScanner.find_device_by_filter(lambda dev, ad: True, timeout=timeout, **scan_args)
+            device = await BleakScanner.find_device_by_filter(lambda dev, ad: True, timeout=timeout, **self.scan_args)
 
         # address_type used only in Windows .NET currently
         # TODO check if passing adapter from from scan data works

--- a/ble_serial/main.py
+++ b/ble_serial/main.py
@@ -25,8 +25,11 @@ class Main():
         parser.add_argument('-p', '--port', dest='port', required=False, default=DEFAULT_PORT,
             help=DEFAULT_PORT_MSG)
 
-        parser.add_argument('-d', '--dev', dest='device', required=True,
+        parser.add_argument('-d', '--dev', dest='device', required=False,
             help='BLE device address to connect (hex format, can be separated by colons)')
+        parser.add_argument('-s', '--service-uuid', dest='service_uuid', required=False,
+            help='The service used for scanning of potential devices')
+
         parser.add_argument('-t', '--timeout', dest='timeout', required=False, default=5.0, type=float, metavar='SEC',
             help='BLE connect/discover timeout in seconds')
         parser.add_argument('-a', '--address-type', dest='addr_type', required=False, choices=['public', 'random'], default='public',
@@ -35,6 +38,7 @@ class Main():
             help='BLE host adapter number to use')
         parser.add_argument('-m', '--mtu', dest='mtu', required=False, default=20, type=int,
             help='Max. bluetooth packet data size in bytes used for sending')
+
         parser.add_argument('-w', '--write-uuid', dest='write_uuid', required=False,
             help='The GATT characteristic to write the serial data, you might use "ble-scan -d" to find it out')
         parser.add_argument('-r', '--read-uuid', dest='read_uuid', required=False,
@@ -48,6 +52,9 @@ class Main():
             help='Log data as raw binary, disable transformation to hex. Works only in combination with -l')
 
         self.args = parser.parse_args()
+
+        if not self.args.device and not self.args.service_uuid:
+            parser.error('at least one of -d/--dev and -s/--service-uuid required')
 
     async def _run(self):
         args = self.args
@@ -65,7 +72,7 @@ class Main():
                 self.uart.set_receiver(self.bt.queue_send)
 
             self.uart.start()
-            await self.bt.connect(args.device, args.addr_type, args.adapter, args.timeout)
+            await self.bt.connect(args.device, args.addr_type, args.adapter, args.timeout, args.service_uuid)
             await self.bt.setup_chars(args.write_uuid, args.read_uuid, args.mode)
 
             logging.info('Running main loop!')

--- a/ble_serial/main.py
+++ b/ble_serial/main.py
@@ -25,30 +25,34 @@ class Main():
         parser.add_argument('-p', '--port', dest='port', required=False, default=DEFAULT_PORT,
             help=DEFAULT_PORT_MSG)
 
-        parser.add_argument('-d', '--dev', dest='device', required=False,
-            help='BLE device address to connect (hex format, can be separated by colons)')
-        parser.add_argument('-s', '--service-uuid', dest='service_uuid', required=False,
-            help='The service used for scanning of potential devices')
 
-        parser.add_argument('-t', '--timeout', dest='timeout', required=False, default=5.0, type=float, metavar='SEC',
+        con_group = parser.add_argument_group('connection parameters')
+        con_group.add_argument('-t', '--timeout', dest='timeout', required=False, default=5.0, type=float, metavar='SEC',
             help='BLE connect/discover timeout in seconds')
-        parser.add_argument('-a', '--address-type', dest='addr_type', required=False, choices=['public', 'random'], default='public',
-            help='BLE address type, either public or random')
-        parser.add_argument('-i', '--interface', dest='adapter', required=False, default='hci0',
+        con_group.add_argument('-i', '--interface', dest='adapter', required=False, default='hci0',
             help='BLE host adapter number to use')
-        parser.add_argument('-m', '--mtu', dest='mtu', required=False, default=20, type=int,
+        con_group.add_argument('-m', '--mtu', dest='mtu', required=False, default=20, type=int,
             help='Max. bluetooth packet data size in bytes used for sending')
 
-        parser.add_argument('-w', '--write-uuid', dest='write_uuid', required=False,
+        dev_group = parser.add_argument_group('device parameters')
+        dev_group.add_argument('-d', '--dev', dest='device', required=False,
+            help='BLE device address to connect (hex format, can be separated by colons)')
+        dev_group.add_argument('-a', '--address-type', dest='addr_type', required=False, choices=['public', 'random'], default='public',
+            help='BLE address type, either public or random')
+        dev_group.add_argument('-s', '--service-uuid', dest='service_uuid', required=False,
+            help='The service used for scanning of potential devices')
+            
+        dev_group.add_argument('-w', '--write-uuid', dest='write_uuid', required=False,
             help='The GATT characteristic to write the serial data, you might use "ble-scan -d" to find it out')
-        parser.add_argument('-r', '--read-uuid', dest='read_uuid', required=False,
+        dev_group.add_argument('-r', '--read-uuid', dest='read_uuid', required=False,
             help='The GATT characteristic to subscribe to notifications to read the serial data')
-        parser.add_argument('--permit', dest='mode', required=False, default='rw', choices=['ro', 'rw', 'wo'],
+        dev_group.add_argument('--permit', dest='mode', required=False, default='rw', choices=['ro', 'rw', 'wo'],
             help='Restrict transfer direction on bluetooth: read only (ro), read+write (rw), write only (wo)')
 
-        parser.add_argument('-l', '--log', dest='filename', required=False,
+        log_group = parser.add_argument_group('logging options')
+        log_group.add_argument('-l', '--log', dest='filename', required=False,
             help='Enable optional logging of all bluetooth traffic to file')
-        parser.add_argument('-b', '--binary', dest='binlog', required=False, action='store_true',
+        log_group.add_argument('-b', '--binary', dest='binlog', required=False, action='store_true',
             help='Log data as raw binary, disable transformation to hex. Works only in combination with -l')
 
         self.args = parser.parse_args()

--- a/ble_serial/main.py
+++ b/ble_serial/main.py
@@ -38,7 +38,7 @@ class Main():
         dev_group.add_argument('-d', '--dev', dest='device', required=False,
             help='BLE device address to connect (hex format, can be separated by colons)')
         dev_group.add_argument('-a', '--address-type', dest='addr_type', required=False, choices=['public', 'random'], default='public',
-            help='BLE address type, either public or random')
+            help='BLE address type, only relevant on Windows, ignored otherwise')
         dev_group.add_argument('-s', '--service-uuid', dest='service_uuid', required=False,
             help='The service used for scanning of potential devices')
             
@@ -66,7 +66,7 @@ class Main():
         loop.set_exception_handler(self.excp_handler)
         try:
             self.uart = UART(args.port, loop, args.mtu)
-            self.bt = BLE_interface(args.adapter, args.addr_type, args.service_uuid)
+            self.bt = BLE_interface(args.adapter, args.service_uuid)
             if args.filename:
                 self.log = FS_log(args.filename, args.binlog)
                 self.bt.set_receiver(self.log.middleware(Direction.BLE_IN, self.uart.queue_write))
@@ -76,7 +76,7 @@ class Main():
                 self.uart.set_receiver(self.bt.queue_send)
 
             self.uart.start()
-            await self.bt.connect(args.device, args.timeout)
+            await self.bt.connect(args.device, args.addr_type, args.timeout)
             await self.bt.setup_chars(args.write_uuid, args.read_uuid, args.mode)
 
             logging.info('Running main loop!')

--- a/ble_serial/main.py
+++ b/ble_serial/main.py
@@ -66,7 +66,7 @@ class Main():
         loop.set_exception_handler(self.excp_handler)
         try:
             self.uart = UART(args.port, loop, args.mtu)
-            self.bt = BLE_interface()
+            self.bt = BLE_interface(args.adapter, args.addr_type, args.service_uuid)
             if args.filename:
                 self.log = FS_log(args.filename, args.binlog)
                 self.bt.set_receiver(self.log.middleware(Direction.BLE_IN, self.uart.queue_write))
@@ -76,7 +76,7 @@ class Main():
                 self.uart.set_receiver(self.bt.queue_send)
 
             self.uart.start()
-            await self.bt.connect(args.device, args.addr_type, args.adapter, args.timeout, args.service_uuid)
+            await self.bt.connect(args.device, args.timeout)
             await self.bt.setup_chars(args.write_uuid, args.read_uuid, args.mode)
 
             logging.info('Running main loop!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bleak >= 0.12.0
+bleak >= 0.14.0
 coloredlogs >= 15.0
 pyserial >= 3.4.0 ;platform_system == "Windows"


### PR DESCRIPTION
closes #53

Allows to use the service UUID for scanning and connection, so the device address can be optional, also on Linux.